### PR TITLE
Revert "Add type annotations to `dd.from_pandas` and `dd.from_delayed…

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -4798,7 +4798,7 @@ class DataFrame(_Frame):
                     )
 
             # Or be a frame directly
-            elif isinstance(other, DataFrame):  # type: ignore[unreachable]
+            elif isinstance(other, DataFrame):
                 raise NotImplementedError(
                     "Dask dataframe does not yet support multi-indexes.\n"
                     f"You tried to index with a frame with these columns: {list(other.columns)}\n"

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -8,7 +8,6 @@ import traceback
 from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
 from numbers import Number
-from typing import Callable, TypeVar, overload
 
 import numpy as np
 import pandas as pd
@@ -140,18 +139,6 @@ infer the metadata. This may lead to unexpected results, so providing
 ``meta`` is recommended. For more information, see
 ``dask.dataframe.utils.make_meta``.
 """
-
-T = TypeVar("T", bound=Callable)
-
-
-@overload
-def insert_meta_param_description(func: T) -> T:
-    ...
-
-
-@overload
-def insert_meta_param_description(pad: int) -> Callable[[T], T]:
-    ...
 
 
 def insert_meta_param_description(*args, **kwargs):


### PR DESCRIPTION
…` (#9237)"

Returning a union of types breaks mypy.  If you run mypy on the example below you get the error `hack/jyap/mypy_test/mypy_test.py:9: error: Argument 1 to "foo" has incompatible type "Union[DataFrame, Series]"; expected "DataFrame"`

```
import dask
import pandas as pd

test_ddf = dask.dataframe.io.from_pandas(pd.DataFrame([]))

def foo(ddf: dask.dataframe.DataFrame) -> dask.dataframe.DataFrame:
    return ddf

foo(test_ddf)
```

This reverts commit 84533ea4018a8bce41d00f0794db5e4bfef57416.

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
